### PR TITLE
Add gem install bundler

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -14,3 +14,4 @@ script: |
   sudo add-apt-repository -y ppa:chris-lea/node.js
   sudo apt-get update
   sudo apt-get install nodejs
+  sudo gem install bundler --no-rdoc --no-ri


### PR DESCRIPTION
# WHY AND WHAT

New version of bundler is needed on installing the latest version of omniauth.
