### PR TITLE
Update PhantomJS to v1.9.8

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -15,3 +15,9 @@ script: |
   curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
   sudo apt-get install -y nodejs
   gem install bundler --no-rdoc --no-ri
+  # Install PhantomJS 1.9.8
+  export PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+  wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
+  sudo tar xvjf $PHANTOM_JS.tar.bz2
+  sudo mv $PHANTOM_JS /usr/local/share
+  sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin


### PR DESCRIPTION
## WHY

Wantedlyの開発では、PhantomJSのバージョンを1.9.8に固定しているはずだが、このboxに入っているのが1.9.7だった。
npmでPhantomJSに依存したライブラリを入れるときに、`1.9.8`が最低バージョンだったため、PhantomJSの再インストールが走っていて、このときに失敗することが多い。
元から`1.9.8`を入れておけば、この状態を改善できる。
## WHAT

https://gist.github.com/julionc/7476620#file-00-howto_install_phantomjs-md を参考に、`1.9.8`をいれるようにした。
