### PR TITLE
Force use /usr/local/share/$PHANTOM_JS/bin/phantomjs

### DIFF
--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -20,4 +20,5 @@ script: |
   wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
   sudo tar xvjf $PHANTOM_JS.tar.bz2
   sudo mv $PHANTOM_JS /usr/local/share
-  sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+  # sudo ln -sf /usr/local/share/$PHANTOM_JS/bin/phantomjs /usr/local/bin
+  sudo mv -f /usr/local/share/$PHANTOM_JS/bin/phantomjs /home/ubuntu/phantomjs/bin/phantomjs


### PR DESCRIPTION
## WHY

```
Considering PhantomJS found at /home/ubuntu/phantomjs/bin/phantomjs
Found PhantomJS at /home/ubuntu/phantomjs/bin/phantomjs ...verifying
PhantomJS detected, but wrong version 1.9.7 @ /home/ubuntu/phantomjs/bin/phantomjs.
```
## WHAT

Force update phantomjs.
