### PR TITLE
Update PhantomJS to v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A wercker box for rvm with some extension
 
 ## CHANGE LOG
 
+### wantedly/rvm-wantedly@0.1.2
+
+* Fix PhantomJS v2.1.1
+
 ### wantedly/rvm-wantedly@0.1.1
 
 * Fix PhantomJS v1.9.8

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -15,8 +15,8 @@ script: |
   curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -
   sudo apt-get install -y nodejs
   gem install bundler --no-rdoc --no-ri
-  # Install PhantomJS 1.9.8
-  export PHANTOM_JS="phantomjs-1.9.8-linux-x86_64"
+  # Install PhantomJS 2.1.1
+  export PHANTOM_JS="phantomjs-2.1.1-linux-x86_64"
   wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
   sudo tar xvjf $PHANTOM_JS.tar.bz2
   sudo mv $PHANTOM_JS /usr/local/share

--- a/wercker-box.yml
+++ b/wercker-box.yml
@@ -1,5 +1,5 @@
 name: rvm-wantedly
-version: 0.1.1
+version: 0.1.2
 inherits: wercker/rvm@6.0.0
 type: main
 platform: ubuntu@12.04


### PR DESCRIPTION
## WHY

To use latest phantomjs
## WHAT
- Update phantomjs 2.1.1
- Bump up the version to 0.1.2
